### PR TITLE
Fix/runtime

### DIFF
--- a/fanControl.ino
+++ b/fanControl.ino
@@ -12,9 +12,9 @@ enum FANSTATE {
   STOPPED
 };
 FANSTATE fanState = STOPPED;
-int fanSpinStartTime;
-int fanRollStartTime;
-int fanStopStartTime;
+long fanSpinStartTime;
+long fanRollStartTime;
+long fanStopStartTime;
 String message;
 
 void setup() {

--- a/fanControl.ino
+++ b/fanControl.ino
@@ -12,9 +12,9 @@ enum FANSTATE {
   STOPPED
 };
 FANSTATE fanState = STOPPED;
-long fanSpinStartTime;
-long fanRollStartTime;
-long fanStopStartTime;
+unsigned long fanSpinStartTime;
+unsigned long fanRollStartTime;
+unsigned long fanStopStartTime;
 String message;
 
 void setup() {

--- a/fanControl.ino
+++ b/fanControl.ino
@@ -79,14 +79,14 @@ void handleFan(){
 }
 
 void handleSpinningFan(){
-  if (millis() < fanSpinStartTime + FAN_SPIN_TIME){
+  if (millis() - fanSpinStartTime < FAN_SPIN_TIME){
     return ;
   }
   switchFanState(ROLLING);
 }
 
 void handleRollingFan(){
-  if (millis() < fanRollStartTime + FAN_ROLL_TIME){
+  if (millis() - fanRollStartTime < FAN_ROLL_TIME){
     return ;
   }
   switchFanState(SPINNING);


### PR DESCRIPTION
# FIXES
- Fixed 32s runtime:<br>
 `millis()` function returns `unsigned long` which is `4bytes`. That means it will rollover to 0 in 50days. Why?<br>
It will happen because 4 bytes can store max number of: `4,294,967,295 (/1000/60/60/24 ~ **50**)`.
Spin/Roll/Stop times were type `int (2bytes)` which means it will `rollover` in ~32s. Thats why I changes its types to `unsigned long` instead of `int`